### PR TITLE
QOL: Normalize EOL to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
# Why?
This prevents some cross-platform headaches in the future