### PR TITLE
34 Standardize module warning output

### DIFF
--- a/vole/modules/abstract.py
+++ b/vole/modules/abstract.py
@@ -27,6 +27,9 @@ class Module(ABC):
     def description(self):
         pass
 
+    def warn(self, func, addr: int) -> str:
+        return f"[{self.cwe_id}] ({self.cwe_name}) in {func.name} @ {hex(addr)}"
+
     @abstractmethod
     def execute(self) -> tuple[dict, str] | None:
         pass


### PR DESCRIPTION
> [!NOTE]
> This branch is based on #23, it will be retargeted to main once that has been merged

# This PR
- Simply adds a standard format for reporting warnings from modules